### PR TITLE
Update box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,12 +2,12 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "bento/debian-8.3"
+  config.vm.box = "bento/debian-8.8"
   config.vm.hostname = 'infratestdemo.localhost.local'
   
   config.vm.provider "virtualbox" do |provider,override|
-    provider.memory = 2048
-    provider.cpus = 4
+    provider.memory = 1024
+    provider.cpus = 2
   end
 
   config.vm.provider :linode do |provider, override|

--- a/saltstack/pillar/infratest/init.sls
+++ b/saltstack/pillar/infratest/init.sls
@@ -19,19 +19,14 @@ infratest:
   package:
     'openssh-server':
       installed: true
-      version: 1:6.7p1-5+deb8u1
+      version: 1:6.7p1-5+deb8u3
     'exim4':
       installed: true
       version: 4.84
   process:
-    'nginx':
-      www-data:
-        count: 4
-      root:
-        count: 1
     'sshd':
       root:
-        count: 5
+        count: 2
   service:
     'exim4':
       running: true
@@ -45,7 +40,7 @@ infratest:
   systeminfo:
     type: linux
     distribution: debian
-    release: '8.3'
+    release: '8.8'
     codename: jessie
   sysctl:
     'kernel.osrelease':


### PR DESCRIPTION
Updates to latest bento image and reduces the resource allocation for the machine. Don't think that 4 cores and 2 gigs of memory is necessary IMO.